### PR TITLE
Add link to lockfree, a collection of lock-free data structures written in standard C++11

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A collection of resources on wait-free and lock-free programming.
 * [libcds](https://github.com/khizmax/libcds) - A C++ library of Concurrent Data Structures.
 * [liblfds](https://liblfds.org/) - portable, license-free, lock-free data structure library written in C.
 * [xenium](https://github.com/mpoeter/xenium) - A C++ library providing various concurrent data structures and reclamation schemes.
+* [lockfree](https://github.com/DNedic/lockfree) - A collection of lock-free data structures written in standard C++11. Configurable and embedded friendly.
 
 ## Websites
 


### PR DESCRIPTION
This adds a link to [lockfree](https://github.com/DNedic/lockfree), a collection of lock-free data structures written in standard C++11.

The library differentiates itself with its no-allocation bounded design, configurability while maintaining readable code (subjectively).